### PR TITLE
feat: profilesテーブルにusersテーブルの外部キー制約追加・portfoliosテーブルを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :test do
 end
 
 gem 'carrierwave'
+gem 'enum_help'
 gem 'jp_prefecture'
 gem 'rails-i18n', '~> 6.0.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ gem 'carrierwave'
 gem 'enum_help'
 gem 'jp_prefecture'
 gem 'rails-i18n', '~> 6.0.0'
+gem 'rinku'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,6 +241,7 @@ GEM
     regexp_parser (2.2.0)
     require_all (3.0.0)
     rexml (3.2.5)
+    rinku (2.0.6)
     rubocop (1.25.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -349,6 +350,7 @@ DEPENDENCIES
   rails (~> 6.1.4, >= 6.1.4.4)
   rails-i18n (~> 6.0.0)
   rails_best_practices
+  rinku
   rubocop
   rubocop-performance
   rubocop-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,8 @@ GEM
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     debug_inspector (1.1.0)
+    enum_help (0.0.18)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     erubis (2.7.0)
     faraday (1.9.3)
@@ -336,6 +338,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   carrierwave
+  enum_help
   jbuilder (~> 2.7)
   jp_prefecture
   listen (~> 3.3)

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -21,5 +21,8 @@
 class Portfolio < ApplicationRecord
   belongs_to :profile
 
+  validate :name, presence: true, length: { maximum: 255 }
+  validate :url, length: { maximum: 255 }
+
   enum status: { untouched: 0, ongoing: 1, released: 2 }
 end

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -3,7 +3,7 @@
 # Table name: portfolios
 #
 #  id         :bigint           not null, primary key
-#  name       :string
+#  name       :string           not null
 #  status     :integer          default(0), not null
 #  url        :string
 #  created_at :datetime         not null

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: portfolios
+#
+#  id         :bigint           not null, primary key
+#  name       :string
+#  status     :integer          default(0), not null
+#  url        :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  profile_id :bigint           not null
+#
+# Indexes
+#
+#  index_portfolios_on_profile_id  (profile_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (profile_id => profiles.id)
+#
+class Portfolio < ApplicationRecord
+  belongs_to :profile
+
+  enum status: { untouched: 0, ongoing: 1, released: 2 }
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -19,6 +19,15 @@
 #  twitter_account   :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  user_id           :bigint
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 class Profile < ApplicationRecord
   belongs_to :user

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -31,6 +31,7 @@
 #
 class Profile < ApplicationRecord
   belongs_to :user
+  has_many :portfolios
   mount_uploader :avatar, AvatarUploader
 
   validate :name, presence: true, length: { maximum: 255 }

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -31,7 +31,7 @@
 #
 class Profile < ApplicationRecord
   belongs_to :user
-  has_many :portfolios
+  has_many :portfolios, dependent: :destroy
   mount_uploader :avatar, AvatarUploader
 
   validate :name, presence: true, length: { maximum: 255 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,5 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :authentications, dependent: :destroy
   accepts_nested_attributes_for :authentications
+  has_one :profile, dependent: :destroy
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,60 @@
+ja:
+  activerecord:
+    models:
+      user: 'ユーザー'
+      profile: 'プロフィール'
+      portfolio: 'ポートフォリオ'
+    attributes:
+      user:
+        github_name: 'GitHubアカウント名'
+        email: 'メールアドレス'
+        remote_avatar_url: 'GitHubアカウント画像'
+      profile:
+        name: '名前'
+        grade: '期'
+        gender: '性別'
+        birthplace_code: '出身地'
+        living_place_code: '居住地'
+        date_of_birth: '生年月日'
+        blood_type: '血液型'
+        siblings_relation: '兄弟関係'
+        hobby: '趣味'
+        times_name: 'times名'
+        team_dev_will: 'チーム開発希望'
+        twitter_account: 'Twitterアカウント'
+        self_introduce: '自己紹介文'
+        avatar: 'プロフィール画像'
+      portfolio:
+        name: 'ポートフォリオ名'
+        url: 'URL'
+        status: '状況'
+  enums:
+    profile:
+      gender:
+        unanswered: '未回答'
+        male: '男性'
+        female: '女性'
+        others: 'その他'
+      blood_type:
+        unanswered: '未回答'
+        A: 'A型'
+        B: 'B型'
+        O: 'O型'
+        AB: 'AB型'
+      siblings_relation:
+        unanswered: '未回答'
+        oldest: '一番上'
+        middle: '真ん中'
+        youngest: '末っ子'
+        have_no_siblings: '一人っ子'
+      team_dev_will:
+        unanswered: '未回答'
+        not_available: '都合がつかない'
+        would_love_to: 'やってみたい!'
+        interested_but: '興味はあるけど踏ん切りがつかない'
+    portfolio:
+      status:
+        untouched: '未着手'
+        ongoing: '絶賛作成中!乞うご期待!(MVPリリース含む)'
+        released: 'リリース済み(ドヤァ)'
+

--- a/db/migrate/20220214084018_add_user_id_to_profiles.rb
+++ b/db/migrate/20220214084018_add_user_id_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddUserIdToProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :profiles, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20220214095538_create_portfolios.rb
+++ b/db/migrate/20220214095538_create_portfolios.rb
@@ -1,0 +1,12 @@
+class CreatePortfolios < ActiveRecord::Migration[6.1]
+  def change
+    create_table :portfolios do |t|
+      t.references :profile, null: false, foreign_key: true
+      t.string :name
+      t.string :url
+      t.integer :status, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220214134724_change_column_notnull_on_portfolios.rb
+++ b/db/migrate/20220214134724_change_column_notnull_on_portfolios.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNotnullOnPortfolios < ActiveRecord::Migration[6.1]
+  def change
+    change_column :portfolios, :name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_14_095538) do
+ActiveRecord::Schema.define(version: 2022_02_14_134724) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2022_02_14_095538) do
 
   create_table "portfolios", force: :cascade do |t|
     t.bigint "profile_id", null: false
-    t.string "name"
+    t.string "name", null: false
     t.string "url"
     t.integer "status", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_14_051030) do
+ActiveRecord::Schema.define(version: 2022_02_14_084018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,8 @@ ActiveRecord::Schema.define(version: 2022_02_14_051030) do
     t.string "avatar"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -54,4 +56,5 @@ ActiveRecord::Schema.define(version: 2022_02_14_051030) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "profiles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_14_084018) do
+ActiveRecord::Schema.define(version: 2022_02_14_095538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,16 @@ ActiveRecord::Schema.define(version: 2022_02_14_084018) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+  end
+
+  create_table "portfolios", force: :cascade do |t|
+    t.bigint "profile_id", null: false
+    t.string "name"
+    t.string "url"
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["profile_id"], name: "index_portfolios_on_profile_id"
   end
 
   create_table "profiles", force: :cascade do |t|
@@ -56,5 +66,6 @@ ActiveRecord::Schema.define(version: 2022_02_14_084018) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "portfolios", "profiles"
   add_foreign_key "profiles", "users"
 end

--- a/test/fixtures/portfolios.yml
+++ b/test/fixtures/portfolios.yml
@@ -3,7 +3,7 @@
 # Table name: portfolios
 #
 #  id         :bigint           not null, primary key
-#  name       :string
+#  name       :string           not null
 #  status     :integer          default(0), not null
 #  url        :string
 #  created_at :datetime         not null

--- a/test/fixtures/portfolios.yml
+++ b/test/fixtures/portfolios.yml
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: portfolios
+#
+#  id         :bigint           not null, primary key
+#  name       :string
+#  status     :integer          default(0), not null
+#  url        :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  profile_id :bigint           not null
+#
+# Indexes
+#
+#  index_portfolios_on_profile_id  (profile_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (profile_id => profiles.id)
+#
+
+one:
+  profile: one
+  name: MyString
+  url: MyString
+  status: 1
+
+two:
+  profile: two
+  name: MyString
+  url: MyString
+  status: 1

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -19,6 +19,15 @@
 #  twitter_account   :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  user_id           :bigint
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 
 one:

--- a/test/models/portfolio_test.rb
+++ b/test/models/portfolio_test.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: portfolios
+#
+#  id         :bigint           not null, primary key
+#  name       :string
+#  status     :integer          default(0), not null
+#  url        :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  profile_id :bigint           not null
+#
+# Indexes
+#
+#  index_portfolios_on_profile_id  (profile_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (profile_id => profiles.id)
+#
+require "test_helper"
+
+class PortfolioTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/portfolio_test.rb
+++ b/test/models/portfolio_test.rb
@@ -3,7 +3,7 @@
 # Table name: portfolios
 #
 #  id         :bigint           not null, primary key
-#  name       :string
+#  name       :string           not null
 #  status     :integer          default(0), not null
 #  url        :string
 #  created_at :datetime         not null

--- a/test/models/portfolio_test.rb
+++ b/test/models/portfolio_test.rb
@@ -18,7 +18,7 @@
 #
 #  fk_rails_...  (profile_id => profiles.id)
 #
-require "test_helper"
+require 'test_helper'
 
 class PortfolioTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -19,6 +19,15 @@
 #  twitter_account   :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  user_id           :bigint
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 require 'test_helper'
 


### PR DESCRIPTION
## 概要
- profilesテーブルにusersテーブルの外部キー制約追加・Userモデルにアソシエーション追記
- portfoliosテーブルを作成・profilesテーブルの外部キー制約をつけPortfolioモデルとProfileモデルにアソシエーション記述
- モデルの翻訳ファイルを追加
- gem 'enum_help'を追加
- gem 'rinku'を追加

以上を行いました。

brakemanを実行し、No warnings foundでした。

close #25

## 確認方法
gemを導入したので`bundle install`をしてください。
作成したマイグレーションファイルを反映させるため`bundle exec rails db:migrate`を実行してください。

## コメント
検討の結果、URLをリンクにするためにrinkuを使うのが一番簡単であると判断したため導入しました。
[Rinku](https://github.com/vmg/rinku)
[使い方参考: simple_formatと組み合わせるといいかもしれません](https://qiita.com/Jackson123/items/a5e21c6d6d229681cb6b)
[Rinkuを使わない場合の方法例](https://chopesu.com/programing/rails-texturl-link/)