### PR TITLE
Herokuへデプロイ

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.5.8)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
@@ -366,6 +368,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   annotate

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/config/database.yml
+++ b/config/database.yml
@@ -69,3 +69,5 @@ production:
   database: hiyoco_connect_production
   username: hiyoco_connect
   password: <%= ENV['HIYOCO_CONNECT_DATABASE_PASSWORD'] %>
+  url:  <%= ENV["DATABASE_URL"] %>
+  pool: <%= ENV['RAILS_MAX_THREADS'] || 5 %>

--- a/config/initializers/rack_lock.rb
+++ b/config/initializers/rack_lock.rb
@@ -1,0 +1,1 @@
+Rails.application.config.middleware.insert_before 0, Rack::Lock

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,43 +1,9 @@
-# Puma can serve each request in a thread from an internal thread pool.
-# The `threads` method setting takes two numbers: a minimum and maximum.
-# Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum; this matches the default thread size of Active Record.
-#
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
-min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
-threads min_threads_count, max_threads_count
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
+threads threads_count, threads_count
 
-# Specifies the `worker_timeout` threshold that Puma will use to wait before
-# terminating a worker in development environments.
-#
-worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
+preload_app!
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-#
-port ENV.fetch('PORT', 3000)
-
-# Specifies the `environment` that Puma will run in.
-#
-environment ENV.fetch('RAILS_ENV', 'development')
-
-# Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
-
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked web server processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
-
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
-# preload_app!
-
-# Allow puma to be restarted by `rails restart` command.
-plugin :tmp_restart
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development


### PR DESCRIPTION
## 概要
Herokuへデプロイをする際、プラットフォームの設定の追加が必要だったため
```
bundle lock --add-platform x86_64-linux
```
上のコマンドを実行し、 8edcc94 にてGemfile.lockに変更を加えました。

## 注意点
### 変更分に関して
- マージ後ローカルに変更分を反映したら`bundle install`を実行してください。(必要ないかも？)

### Herokuに関して
[Heroku teams](https://devcenter.heroku.com/ja/articles/heroku-teams)を使い、チームでこのアプリを管理できるようにしました。
皆さんのローカル上からpushする際は、まずHerokuのremoteリポジトリとの紐付けの設定をお願いします！
```
git remote add heroku https://git.heroku.com/hiyoco-connect.git
```
で設定できます。

```
heroku git:remote -a hiyoco-connect
```
でも同様に紐づけられます。

push時はmainブランチで
```
git push heroku main
```
を実行してください。