### PR TITLE
feat: ヘッダーにマイページ,プロフィール一覧を追加 #59

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,7 +1,7 @@
 <header>
 <nav class="navbar bg-primary navbar-expand-md">
   <div class="container-fluid">
-    <%= link_to (t 'defaults.app_title'), profiles_path, class: 'navbar-brand text-dark' %>
+    <%= link_to (t 'defaults.app_title'), root_path, class: 'navbar-brand text-dark' %>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header>
 <nav class="navbar bg-primary navbar-expand-md">
   <div class="container-fluid">
-    <%= link_to (t 'defaults.app_title'), profiles_path, class: 'navbar-brand text-dark' %>
+    <%= link_to (t 'defaults.app_title'), root_path, class: 'navbar-brand text-dark' %>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
@@ -10,12 +10,6 @@
       <ul class="navbar-nav mr-auto mb-2 mb-md-0">
         <li class="nav-item">
           <%= link_to (t 'defaults.logout'), logout_path, method: :delete, class: "nav-link active text-dark" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to (t 'defaults.mypage'), profile_path(current_user.id), class: "nav-link active text-dark" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to (t 'defaults.profiles_all'), profiles_path, class: "nav-link active text-dark" %>
         </li>
       </ul>
     </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -11,8 +11,6 @@ ja:
     login: 'ログイン'
     logout: 'ログアウト'
     not_answered: '未回答'
-    mypage: 'マイページ'
-    profiles_all: 'プロフィール一覧'
   oauths:
     callback:
       to_login: 'ログインする'


### PR DESCRIPTION
### 概要
- ヘッダーにマイページ,プロフィール一覧を追加しました。
- 左上のひよこコネクトを押したらプロフィール一覧ページに遷移するよう修正しました。
![localhost_3000_ (2)](https://user-images.githubusercontent.com/79771445/156576192-b11b68e0-543e-44c6-9687-6525ceec4b49.png)
### rubocop
```ruby
Inspecting 44 files
............................................

44 files inspected, no offenses detected
```

close #59 