### PR TITLE
プロフィール削除機能を実装

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -37,6 +37,10 @@ class ProfilesController < ApplicationController
     end
   end
 
+  def destroy
+    current_user.profile.destroy
+    redirect_to root_path, success: t('defaults.messages.deleted', item: Profile.model_name.human)
+  end
   def likes
     @liked_profiles = current_user.liked_profiles.includes(:user).grade_desc.name_asc
     @connect_profiles = current_user.connect.includes(:user).grade_desc.name_asc

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -41,6 +41,7 @@ class ProfilesController < ApplicationController
     current_user.profile.destroy
     redirect_to root_path, success: t('defaults.messages.deleted', item: Profile.model_name.human)
   end
+
   def likes
     @liked_profiles = current_user.liked_profiles.includes(:user).grade_desc.name_asc
     @connect_profiles = current_user.connect.includes(:user).grade_desc.name_asc

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -39,7 +39,7 @@ class ProfilesController < ApplicationController
 
   def destroy
     current_user.profile.destroy
-    redirect_to root_path, success: t('defaults.messages.deleted', item: Profile.model_name.human)
+    redirect_to profiles_path, success: t('defaults.messages.deleted', item: Profile.model_name.human)
   end
 
   def likes

--- a/app/views/profiles/_portfolio_fields.html.erb
+++ b/app/views/profiles/_portfolio_fields.html.erb
@@ -5,7 +5,7 @@
   <div class="row justify-content-center mb-3">
     <div class="col-lg-2"></div>
     <div class="col-3 col-lg-2 text-end">
-      <%= f.label :name, class: 'col-form-label' %>
+      <%= f.label :name, class: 'col-form-label' %><span class="text-danger">*</span>
     </div>
 
     <div class="col-6 col-lg-5">

--- a/app/views/profiles/_portfolio_fields.html.erb
+++ b/app/views/profiles/_portfolio_fields.html.erb
@@ -5,7 +5,7 @@
   <div class="row justify-content-center mb-3">
     <div class="col-lg-2"></div>
     <div class="col-3 col-lg-2 text-end">
-      <%= f.label :name, class: 'col-form-label' %><span class="text-danger">*</span>
+      <%= f.label :name, class: 'col-form-label' %>
     </div>
 
     <div class="col-6 col-lg-5">

--- a/app/views/profiles/likes.html.erb
+++ b/app/views/profiles/likes.html.erb
@@ -5,7 +5,7 @@
       <% if @connect_profiles.present? %>
         <%= render @connect_profiles %>
       <% else %>
-        <p><%= t 'connect_profile_not_found_message' %></p>
+        <p><%= t '.connect_profile_not_found_message' %></p>
       <% end %>
       <h2><%= t '.like' %></h2>
       <% if @liked_profiles.present? %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -271,7 +271,7 @@
         <% end %>
 
         <%= link_to profile_path(@profile), method: :delete, data: { confirm: t('defaults.messages.delete_confirm') } do %>
-          <div class="btn btn-danger ms-1"><i class="fa fa-trash me-1"></i>削除</div>
+          <div class="btn btn-danger ms-1"><i class="fa fa-trash"></i></div>
         <% end %>
       </div>
     </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -267,11 +267,11 @@
     <div class="row text-center mt-5">
       <div>
         <%= link_to edit_profile_path(@profile), class: 'text-decoration-none' do %>
-          <div class="btn btn-success"><i class="fas fa-pen"></i> 編集</div>
+          <div class="btn btn-success"><i class="fas fa-pen me-1"></i>編集</div>
         <% end %>
 
         <%= link_to profile_path(@profile), method: :delete, data: { confirm: t('defaults.messages.delete_confirm') } do %>
-          <div class="btn btn-danger ms-1"><i class="fa fa-trash"></i></div>
+          <div class="btn btn-danger ms-1"><i class="fa fa-trash me-1"></i>削除</div>
         <% end %>
       </div>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,7 +12,7 @@
             <%= link_to (t 'defaults.profiles_all'), profiles_path, class: "nav-link active text-dark" %>
           </li>
           <li class="nav-item">
-            <%= link_to (t 'defaults.mypage'), profile_path(current_user.id), class: "nav-link active text-dark" %>
+            <%= link_to (t 'defaults.myprofile'), profile_path(current_user.profile.id), class: "nav-link active text-dark" if current_user.profile.present?%>
           </li>
           <li class="nav-item">
             <%= link_to (t 'defaults.like'), likes_profiles_path, class: "nav-link active text-dark" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,9 +11,15 @@
           <li class="nav-item">
             <%= link_to (t 'defaults.profiles_all'), profiles_path, class: "nav-link active text-dark" %>
           </li>
+        <%if current_user.profile.present?%>
           <li class="nav-item">
-            <%= link_to (t 'defaults.myprofile'), profile_path(current_user.profile.id), class: "nav-link active text-dark" if current_user.profile.present?%>
+            <%= link_to (t 'defaults.myprofile'), profile_path(current_user.profile.id), class: "nav-link active text-dark" %>
           </li>
+        <%else%>
+          <li class="nav-item">
+            <%= link_to (t 'defaults.profile_new'), new_profile_path, class: "nav-link active text-dark"%>
+          </li>
+        <%end%>
           <li class="nav-item">
             <%= link_to (t 'defaults.like'), likes_profiles_path, class: "nav-link active text-dark" %>
           </li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -11,8 +11,9 @@ ja:
     login: 'ログイン'
     logout: 'ログアウト'
     not_answered: '未回答'
-    myprofile: 'マイページ'
+    myprofile: 'マイプロフィール'
     profiles_all: 'プロフィール一覧'
+    profile_new: 'プロフィール作成'
     like: 'いいね！'
   oauths:
     callback:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -11,7 +11,7 @@ ja:
     login: 'ログイン'
     logout: 'ログアウト'
     not_answered: '未回答'
-    mypage: 'マイページ'
+    myprofile: 'マイページ'
     profiles_all: 'プロフィール一覧'
     like: 'いいね！'
   oauths:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root to: 'static_pages#top'
-  resources :profiles, only: %i[new create index show edit update] do
+  resources :profiles do
     resource :like, only: %i[create destroy]
     collection do
       get 'search'


### PR DESCRIPTION
### 対応issue
#74 プロフィールを未作成でマイページボタンを押すとエラーになる
#58 プロフィール削除機能の実装
close #74 
close #58 
### 詳細

1ed2753 でプロフィールの有無によってヘッダーにマイプロフィールリンクが表示されるように修正しました。
![localhost_3000_profiles_122 (1)](https://user-images.githubusercontent.com/79771445/157059722-3b345140-867e-4fbd-aec3-561b760ff4e6.png)

6ffc0c6 でプロフィール削除機能を追加しました。削除された後はrootにリダイレクトされるようにしています。
![localhost_3000_ (4)](https://user-images.githubusercontent.com/79771445/157060041-b3a65199-011b-4ed0-bbc8-69be882414b6.png)



9f7cc41 で必須項目に米マークを追加しています。
![localhost_3000_profiles (5)](https://user-images.githubusercontent.com/79771445/157059739-658e6963-4226-4092-bfae-082d7f7071a1.png)

090f3ab で削除・編集ボタンのスタイルを修正しています。
![localhost_3000_profiles_122](https://user-images.githubusercontent.com/79771445/157059691-cf65db88-b174-43ab-bd40-01e3d8dcde8a.png)

7fa05df で翻訳エラーを解消しています。
![localhost_3000_profiles_likes](https://user-images.githubusercontent.com/79771445/157059729-4807a4c8-f7ee-499e-ba0b-c79187018328.png)
### rubocop/brakeman
rubocopに指摘事項なし。
brakemanは #36 と同じ指摘事項がありましたが、同様に無害であると判断します。
### 確認方法
サーバーを立ち上げた後、profiles/newでプロフィールを作成してください。
その後ヘッダーにマイプロフィールリンクが表示されることを確認ください。
マイプロフィールリンクを押した時、自分のプロフィールが表示されることを確認ください。
自分のプロフィール画面で削除ボタンを押した時に正常にプロフィールを削除できることを確認ください。