### PR TITLE
fix: いいねされたプロフィールを削除できないエラーを解消

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -32,6 +32,7 @@
 class Profile < ApplicationRecord
   belongs_to :user
   has_many :portfolios, dependent: :destroy
+  has_many :likes, dependent: :destroy
   accepts_nested_attributes_for :portfolios, reject_if: proc { |attributes|
                                                           attributes['name'].blank?
                                                         }


### PR DESCRIPTION
## 概要
プロフィールがいいね！された状態である場合に、そのプロフィールを削除しようとすると
```
ActiveRecord::InvalidForeignKey at /profiles/101
PG::ForeignKeyViolation: ERROR:  update or delete on table "profiles" violates foreign key constraint "fk_rails_1cf78c0e99" on table "likes"
DETAIL:  Key (id)=(101) is still referenced from table "likes".
```
のようなエラーが発生。likesテーブルからまだ参照されているので削除できない。

models/profile.rbに`has_many :likes, dependent: :destroy`を記載していなかったことが原因。
ローカル上でこれを追記し、削除可能になると確認しました。
close #85 