### PR TITLE
Passive likes #79

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -46,6 +46,7 @@ class ProfilesController < ApplicationController
   def likes
     @liked_profiles = current_user.liked_profiles.includes(:user).grade_desc.name_asc
     @connect_profiles = current_user.connect.includes(:user).grade_desc.name_asc
+    @passive_liked_profiles = current_user.passive_liked_profiles.includes(:user).grade_desc.name_asc - @connect_profiles
   end
 
   def search; end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -46,7 +46,8 @@ class ProfilesController < ApplicationController
   def likes
     @liked_profiles = current_user.liked_profiles.includes(:user).grade_desc.name_asc
     @connect_profiles = current_user.connect.includes(:user).grade_desc.name_asc
-    @passive_liked_profiles = current_user.passive_liked_profiles.includes(:user).grade_desc.name_asc - @connect_profiles
+    @passive_liked_profiles = current_user.passive_liked_profiles.includes(:user)
+                                          .grade_desc.name_asc - @connect_profiles
   end
 
   def search; end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-# == Schema Information
+# == Schema Info
 #
 # Table name: users
 #
@@ -21,8 +21,6 @@ class User < ApplicationRecord
   has_many :authentications, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :liked_profiles, through: :likes, source: :profile
-  has_many :passive_likes, class_name: 'Like', foreign_key: 'profile_id',
-                           inverse_of: 'profile', dependent: :destroy
 
   has_one :profile, dependent: :destroy
 
@@ -46,5 +44,13 @@ class User < ApplicationRecord
 
   def connect
     Profile.where(id: liked_profiles.select(:profile_id)).where(id: passive_likes.select(:user_id))
+  end
+
+  def passive_likes
+    Like.where(profile_id: profile.id)
+  end
+
+  def passive_liked_profiles
+    Profile.where(id: passive_likes.select(:user_id))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-# == Schema Info
+# == Schema Infomation
 #
 # Table name: users
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-# == Schema Infomation
+# == Schema Information
 #
 # Table name: users
 #

--- a/app/views/profiles/likes.html.erb
+++ b/app/views/profiles/likes.html.erb
@@ -13,6 +13,10 @@
       <% else %>
         <p><%= t '.like_profile_not_found_message' %></p>
       <% end %>
+      <% if current_user.profile.present? && @passive_liked_profiles.present?%>
+        <h2>いいね！してくれたユーザー</h2>
+        <%= render @passive_liked_profiles %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/profiles/likes.html.erb
+++ b/app/views/profiles/likes.html.erb
@@ -14,7 +14,7 @@
         <p><%= t '.like_profile_not_found_message' %></p>
       <% end %>
       <% if current_user.profile.present? && @passive_liked_profiles.present?%>
-        <h2>いいね！してくれたユーザー</h2>
+        <h2><%= t '.passive_like' %></h2>
         <%= render @passive_liked_profiles %>
       <% end %>
     </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -45,6 +45,7 @@ ja:
     likes:
       connect: 'コネクトしたユーザー'
       like: 'いいね！したユーザー'
+      passive_like: 'いいね！してくれたユーザー'
       connect_profile_not_found_message: 'まだコネクトしていません…'
       like_profile_not_found_message: 'まだいいね！していません…'
   shared:


### PR DESCRIPTION
## 概要
以下2つのissue対応。

**いいね！一覧に「いいね！してくれたユーザーを追加** https://github.com/hiyoco-connect/hiyoco-connect/issues/79
**コネクトしたユーザーがいいねページに表示されない** https://github.com/hiyoco-connect/hiyoco-connect/issues/86

## コネクトしたユーザーがいいねページに表示されない対応
一度作成したプロフィールを削除し、再度作成するとコネクトしたユーザーが表示されないバグが発見された。
```app/models/user.rb```にて、いいね！されているユーザー取得のための関連付け記述に問題があると判断。
関連付けの記述を削除し、下記インスタンスメソッドにていいねされているユーザーを取得出来るように記述した。
```
  def passive_likes
    Like.where(profile_id: profile.id)
  end

  def passive_liked_profiles
    Profile.where(id: passive_likes.select(:user_id))
  end
```

## スクショ
**rails console上にて、current__userをバクフーンにいいねさせる。**
[![Image from Gyazo](https://i.gyazo.com/2b516bc66c635584f4ed36a76a4ac32e.png)](https://gyazo.com/2b516bc66c635584f4ed36a76a4ac32e)
[![Image from Gyazo](https://i.gyazo.com/00c0bcb8d9cd6b2844d7ab6252fb43fc.png)](https://gyazo.com/00c0bcb8d9cd6b2844d7ab6252fb43fc)

**いいね！一覧画面でバクフーンがいいね！してくれたユーザーに追加されている。**
[![Image from Gyazo](https://i.gyazo.com/080c81d52985375e4541358d9e9edc61.png)](https://gyazo.com/080c81d52985375e4541358d9e9edc61)

**バクフーンをいいね！するとコネクトしたユーザーに表示される。
いいね！してくれたユーザーは表示されなくなる。**
[![Image from Gyazo](https://i.gyazo.com/f4407fcc87ee776802bf4e97b3992cf4.png)](https://gyazo.com/f4407fcc87ee776802bf4e97b3992cf4)

## 確認方法
上記を参考にrails console上でcurrent_userをいいねさせてコネクトされるか確認してください。

## rubocopとbrakeman
rubocopに指摘事項なし。
brakemanは https://github.com/hiyoco-connect/hiyoco-connect/pull/36 と同じ指摘事項がありましたが、同様に無害であると判断します。

## コメント
皆さんのお時間頂き、バグ解消ペアプロありがとうございました！

close #79 
close #86 