### PR TITLE
fix: 出身地と居住地を未回答にできるよう修正

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -117,35 +117,38 @@
 
 
   <!-- 出身地 -->
-  <div class="row justify-content-center mb-3">
-    <div class="col-3 col-lg-2 text-end fw-bold col-form-label">
-      <%= (t 'activerecord.attributes.profile.birthplace') %>
-    </div>
-
-    <div class="col-6 col-lg-5">
-      <div class="text-center form-control">
-        <%= @profile.birthplace.name %>
+  <% if @profile.birthplace.present? %>
+    <div class="row justify-content-center mb-3">
+      <div class="col-3 col-lg-2 text-end fw-bold col-form-label">
+        <%= (t 'activerecord.attributes.profile.birthplace') %>
       </div>
-    </div>
 
-    <div class="col-2 col-lg-1"></div>
-  </div>
+      <div class="col-6 col-lg-5">
+        <div class="text-center form-control">
+          <%= @profile.birthplace.name %>
+        </div>
+      </div>
+
+      <div class="col-2 col-lg-1"></div>
+    </div>
+  <% end %>
 
   <!-- 居住地 -->
-  <div class="row justify-content-center mb-3">
-    <div class="col-3 col-lg-2 text-end fw-bold col-form-label">
-      <%= (t 'activerecord.attributes.profile.living_place') %>
-    </div>
-
-    <div class="col-6 col-lg-5">
-      <div class="text-center form-control">
-        <%= @profile.living_place.name %>
+  <% if @profile.living_place.present? %>
+    <div class="row justify-content-center mb-3">
+      <div class="col-3 col-lg-2 text-end fw-bold col-form-label">
+        <%= (t 'activerecord.attributes.profile.living_place') %>
       </div>
+
+      <div class="col-6 col-lg-5">
+        <div class="text-center form-control">
+          <%= @profile.living_place.name %>
+        </div>
+      </div>
+
+      <div class="col-2 col-lg-1"></div>
     </div>
-
-    <div class="col-2 col-lg-1"></div>
-  </div>
-
+  <% end %>
 
   <!-- 趣味 -->
   <div class="row justify-content-center mb-3">

--- a/app/views/shared/_profile_form.html.erb
+++ b/app/views/shared/_profile_form.html.erb
@@ -105,7 +105,7 @@
     </div>
 
     <div class="col-6 col-lg-5">
-      <%= f.collection_select :birthplace_code, JpPrefecture::Prefecture.all, :code, :name, {}, { class: 'form-control text-center pulldown' } %>
+      <%= f.collection_select :birthplace_code, JpPrefecture::Prefecture.all, :code, :name, { include_blank: '未回答' }, { class: 'form-control text-center pulldown' } %>
     </div>
 
     <div class="col-2 col-lg-1"></div>
@@ -118,7 +118,7 @@
     </div>
 
     <div class="col-6 col-lg-5">
-      <%= f.collection_select :living_place_code, JpPrefecture::Prefecture.all, :code, :name, {}, { class: 'form-control text-center pulldown' } %>
+      <%= f.collection_select :living_place_code, JpPrefecture::Prefecture.all, :code, :name, { include_blank: '未回答' }, { class: 'form-control text-center pulldown' } %>
     </div>
 
     <div class="col-2 col-lg-1"></div>


### PR DESCRIPTION
## 概要
今までは出身地と居住地をセレクトボックスで入力する際、選択肢が47都道府県名のみで未回答を選択することができませんでした。
セレクトボックスのHTMLで`include_blank`オプションを指定することで、未回答の場合はプロフィール情報の`birthplace_code`と`living_place_code`のカラムがnilのままプロフィール作成・更新ができるようにしました。
プロフィール詳細ページでは、`birthplace_code`, `living_place_code` がnilの場合は表示しないように条件分岐を設定しました。

close #64
![image](https://user-images.githubusercontent.com/87419889/158727958-b8c4d65c-106f-4d1c-bb6f-4452c88ada72.png)
![image](https://user-images.githubusercontent.com/87419889/158727969-6c88e9dd-c7c8-4885-a3c2-e71cb591d58a.png)

## rubocop, brakeman
rubocopに指摘事項なし。
brakemanは #36 と同じ指摘事項がありましたが、同様に無害であると判断します。

## 確認方法
サーバーを立ち上げ、プロフィール作成・編集ページで出身地・居住地が未回答の状態で新規作成または更新を行ってください。