### PR TITLE
fix: ヘッダー内のハンバーガーメニューアイコンが表示されないバグを修正

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,15 +12,13 @@
             <%= link_to (t 'defaults.profiles_all'), profiles_path, class: "nav-link active text-dark" %>
           </li>
 
-        <% if current_user.profile.present? && current_user.profile.persisted? %>
           <li class="nav-item">
-            <%= link_to (t 'defaults.myprofile'), profile_path(current_user.profile.id), class: "nav-link active text-dark" %>
+            <% if current_user.profile.present? && current_user.profile.persisted? %>
+              <%= link_to (t 'defaults.myprofile'), profile_path(current_user.profile.id), class: "nav-link active text-dark" %>
+             <% else %>
+              <%= link_to (t 'defaults.profile_new'), new_profile_path, class: "nav-link active text-dark"%>
+            <% end %>
           </li>
-        <% else %>
-          <li class="nav-item">
-            <%= link_to (t 'defaults.profile_new'), new_profile_path, class: "nav-link active text-dark"%>
-          </li>
-        <% end %>
 
           <li class="nav-item">
             <%= link_to (t 'defaults.like'), likes_profiles_path, class: "nav-link active text-dark" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <nav class="navbar bg-primary navbar-expand-md">
+  <nav class="navbar navbar-light bg-primary navbar-expand-md">
     <div class="container-fluid">
       <%= link_to (t 'defaults.app_title'), profiles_path, class: 'navbar-brand text-dark' %>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
### 概要
ウィンドウサイズがmd以下になった場合に、ヘッダー内のハンバーガーメニューアイコンが表示されないバグを修正しました。
nav要素に `navbar-light`クラスを指定していないことがバグの原因でした。

### スクショ
<img width="663" alt="image" src="https://user-images.githubusercontent.com/84756197/159155630-5f8ad4da-9a1e-4fd1-a5da-e4364a595757.png">

### コメント
インデントの修正なども併せてに行いました。
動作に変更はありません。

close #100 